### PR TITLE
[Feature] Provide log.check() to log output based on boolean tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,36 @@ if one is set -- the log file.
 | **log.debug(...)**  | **log.warn(...)**   | **log.fatal(...)**  |
 |                     |                     |                     |
 
+It also provides a `log.check()`.  The function accepts the same
+arguments as Lua's standard `assert()`, along with an optional third
+argument naming the level at which to log the assertion.  For example:
+
+```lua
+log.check(x == y, "X and Y are not equal.", "debug")
+```
+
+This code is equivalent to:
+
+```lua
+if not x == y then
+  log.debug("X and Y are not equal.")
+end
+```
+
+If the third argument is nil then the function uses the value of
+`warn`.  Like the standard `assert()` function, the `log.check()`
+function will return the value of its first argument.
+
+Similar the `assert()`, the second parameter is also optional, in
+which case `log.check()` will default to the message `check failed`,
+e.g. these examples are equivalent:
+
+```lua
+log.check(x == y)
+
+log.check(x == y, "check failed", "warn)
+```
+
 
 ### Additional options
 log.lua provides variables for setting additional options:

--- a/log.lua
+++ b/log.lua
@@ -1,7 +1,13 @@
 --
 -- log.lua
 --
--- Copyright (c) 2014, rxi
+-- Copyright (c) 2014, 2015 rxi
+--
+-- Original Author:
+--     rxi
+--
+-- Contributions by:
+--     Eric James Michael Ritz <ejmr@plutono.com>
 --
 -- This library is free software; you can redistribute it and/or modify it
 -- under the terms of the MIT license. See LICENSE for details.
@@ -49,39 +55,55 @@ local tostring = function(...)
 end
 
 
-for i, x in ipairs(modes) do
-  local nameupper = x.name:upper()
-  log[x.name] = function(...)
-    
-    -- Return early if we're below the log level
-    if i < levels[log.level] then
-      return
-    end
+local create_output = function (level, filename, fileline, ...)
+  local levelname = level:upper()
+  local lineinfo = filename .. ":" .. fileline
+  local msg = tostring(...)
+  local color = modes[levels[level]]["color"]
 
-    local msg = tostring(...)
-    local info = debug.getinfo(2, "Sl")
-    local lineinfo = info.short_src .. ":" .. info.currentline
+  -- Return early if we're below the log level
+  if levels[level] < levels[log.level] then
+    return
+  end
 
-    -- Output to console
-    print(string.format("%s[%-6s%s]%s %s: %s",
-                        log.usecolor and x.color or "",
-                        nameupper,
-                        os.date("%H:%M:%S"),
-                        log.usecolor and "\27[0m" or "",
-                        lineinfo,
-                        msg))
+  -- Output to console
+  print(string.format("%s[%-6s%s]%s %s: %s",
+                      log.usecolor and color or "",
+                      levelname,
+                      os.date("%H:%M:%S"),
+                      log.usecolor and "\27[0m" or "",
+                      lineinfo,
+                      msg))
 
-    -- Output to log file
-    if log.outfile then
-      local fp = io.open(log.outfile, "a")
-      local str = string.format("[%-6s%s] %s: %s\n",
-                                nameupper, os.date(), lineinfo, msg)
-      fp:write(str)
-      fp:close()
-    end
-
+  -- Output to log file
+  if log.outfile then
+    local fp = io.open(log.outfile, "a")
+    local str = string.format("[%-6s%s] %s: %s\n",
+                              levelname, os.date(), lineinfo, msg)
+    fp:write(str)
+    fp:close()
   end
 end
 
+
+for _, x in ipairs(modes) do
+  log[x.name] = function(...)
+    local info = debug.getinfo(2, "Sl")
+    create_output(x.name, info.short_src, info.currentline, ...)
+  end
+end
+
+
+log.check = function (value, message, levelname)
+  local output = message or "check failed"
+  local level = levelname or "warn"
+  local info = debug.getinfo(2, "Sl")
+
+  if not value then
+    create_output(level, info.short_src, info.currentline, output)
+  end
+
+  return value
+end
 
 return log


### PR DESCRIPTION
It is currently possible to create debugging output based on the
results of a boolean condition by writing code like so:

```
if enemy.hp <= 0 then
    log.warn("Spawned an enemy with no health.")
end
```

This patch provides a new function, log.check(), allowing us to
rewrite the above as this:

```
log.check(enemy.hp <= 0, "Spawned an enemy with no health.")
```

We are hardly saving much with regard to lines-of-code.  However,
log.check() lets us omit the second parameter, meaning we can write:

```
log.check(enemy.hp <= 0)
```

This will produce a warning, via log.warn(), with the message "Check
failed".  Thus log.check() shares the same order and optional
parameters as Lua's standard assert().  The key difference is that
log.check() will not raise an error like assert().  It only performs
logging; if the failure of a condition is so serious that it requires
raising an error then we must still resort to functions like assert()
and error().

By default log.check() uses the "warn" level.  It accepts an optional
third parameter: the name of a level at which to produce the output.
For example:

```
log.check(player.xp >= MAX_FOR_CLASS,
          "Player exceeded experience points for class.",
          "trace")
```

This will log the message by using the log.trace() function.

The naive implementation of log.check() looks like this:

```
log.check = function (value, message, level)
    local level = level or "warn"
    if not value then
        log[level](message)
    end
    return value
end
```

This definition is flawed because all messages logged will use the
filename and line number where log.check() is defined.  What we want,
however, is for the function to display the file information regarding
the call-site of log.check().  We can call debug.getinfo() from within
log.check() to get the correct information we wish to display, but we
have no way of sending that to the log output.

Our solution for this is to refactor a large chunk of the logic within
the six base logging functions.  This patch introduces the new,
private create_output() function for that purpose.  It accepts not
only the level of message to create, e.g. 'error', but also takes file
information that the original logic obtained from debug.getinfo().
Refactoring the logic into create_output() allows us to obtain the
correct debug.getinfo() information from within log.check(),
ultimately making it possible for the function to display data about
the call-site of log.check() just like all other log functions.
